### PR TITLE
OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: required
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
    - $HOME/.m2

--- a/releng/tools.vitruv.domains.automotive.updatesite/pom.xml
+++ b/releng/tools.vitruv.domains.automotive.updatesite/pom.xml
@@ -7,10 +7,10 @@
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
 		<version>0.3.0-SNAPSHOT</version>
-		<relativePath>../tools.vitruv.domains.parent</relativePath>
+		<relativePath>../tools.vitruv.domains.automotive.parent</relativePath>
 	</parent>
 	
-	<artifactId>tools.vitruv.domains.updatesite</artifactId>
+	<artifactId>tools.vitruv.domains.automotive.updatesite</artifactId>
 	<name>Vitruv Domains Update Site</name>
 	<packaging>eclipse-repository</packaging>
 	


### PR DESCRIPTION
Change Travis build to OpenJDK (as OracleJDK 8 is not supported anymore) and fix a bug in the POM of the updatesite project, which should have actually led to compile errors already before.